### PR TITLE
Fix fatal error when initializing Session with Fees object

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -39,9 +39,12 @@ class Session
         InitializeCustomer $customer = null,
         string $reference = null
     ) {
-        if (!isset($fees['provider'])) {
+        if ($fees instanceof Fees) {
             $fees = $fees->toArray();
+        } elseif (!is_array($fees)) {
+            throw new \InvalidArgumentException('Fees must be an instance of Fees or an array.');
         }
+
         $cart = $cart->toArray();
 
         if (!in_array($countryCode, $this->validCountryCodes)) {


### PR DESCRIPTION
Fixes #17. Properly check if `$fees` is a `Fees` object before accessing it as an array. This prevents the `Cannot use object of type Fees as array` error when calling `Session::initialize()` with a `Fees` object as the second parameter.